### PR TITLE
test: guards for the two things that could not be checked by hand

### DIFF
--- a/Tests/HelmRuntimeTests/ResetRemovesOnlyItsOwnTests.swift
+++ b/Tests/HelmRuntimeTests/ResetRemovesOnlyItsOwnTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import HelmRuntime
+
+/// The reset, exercised on a home directory it may destroy.
+///
+/// `ResetPlanTests` asks the gate questions. This asks the *machinery*: hand
+/// `HelmTrash` what `ResetPlan` produces, against a real directory tree, and
+/// see what survives. It is the only part of "reset everything" with anything
+/// to get wrong — the other two steps are `removePersistentDomain` and a
+/// relaunch, both single system calls with no logic of their own.
+///
+/// Written because the button could not be driven on the development machine
+/// (the status item sits on a second display and the automation would not reach
+/// it), and "untested" is not a state this particular feature may ship in.
+final class ResetRemovesOnlyItsOwnTests: XCTestCase {
+    private var home: String!
+
+    override func setUpWithError() throws {
+        home = NSTemporaryDirectory() + "reset-test-" + UUID().uuidString
+        // The two directories a reset is allowed to take…
+        for path in ResetPlan.removablePaths(home: home) {
+            try FileManager.default.createDirectory(atPath: path + "/Disk",
+                                                   withIntermediateDirectories: true)
+            try "state".write(toFile: path + "/Disk/last-scan.json", atomically: true,
+                              encoding: .utf8)
+        }
+        // …and three neighbours it is not. The last one is the trap: a sibling
+        // whose name starts the same way.
+        for path in ["\(home!)/Library/Application Support/Sketch",
+                     "\(home!)/Library/Logs/DiagnosticReports",
+                     "\(home!)/Library/Application Support/Helmet"] {
+            try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
+            try "keep me".write(toFile: path + "/file.txt", atomically: true, encoding: .utf8)
+        }
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(atPath: home)
+    }
+
+    func testItTakesHelmsTwoDirectoriesAndLeavesTheNeighbours() throws {
+        let paths = ResetPlan.removablePaths(home: home)
+            .filter { ResetPlan.mayRemove($0, home: home) }
+        XCTAssertEqual(paths.count, 2, "the plan and its own gate disagree")
+
+        let result = HelmTrash.remove(allowed: paths, module: "reset-test")
+
+        XCTAssertEqual(result.removed.count, 2, "refused: \(result.refused)")
+        XCTAssertTrue(result.refused.isEmpty)
+        for path in paths {
+            XCTAssertFalse(FileManager.default.fileExists(atPath: path),
+                           "\(path) survived a reset")
+        }
+        // The neighbours, including the one whose name merely starts alike.
+        for path in ["\(home!)/Library/Application Support/Sketch/file.txt",
+                     "\(home!)/Library/Logs/DiagnosticReports/file.txt",
+                     "\(home!)/Library/Application Support/Helmet/file.txt"] {
+            XCTAssertTrue(FileManager.default.fileExists(atPath: path),
+                          "a reset destroyed \(path), which is not Helm's")
+        }
+        // And the containers themselves, which a careless plan would have named.
+        for path in ["\(home!)/Library/Application Support", "\(home!)/Library/Logs",
+                     "\(home!)/Library", home!] {
+            XCTAssertTrue(FileManager.default.fileExists(atPath: path),
+                          "\(path) is not Helm's to remove")
+        }
+    }
+
+    /// To the Trash, not past it: somebody who presses this by accident has to
+    /// be able to get their Autopilot rules back. `HelmTrash` reports what it
+    /// freed, which is only true of a move it actually performed.
+    func testWhatItRemovedIsRecoverable() throws {
+        let paths = ResetPlan.removablePaths(home: home)
+        let result = HelmTrash.remove(allowed: paths, module: "reset-test")
+        XCTAssertGreaterThan(result.freedBytes, 0,
+                             "nothing was measured as freed, so nothing moved")
+    }
+}

--- a/Tests/HelmUITests/RingSpinnerTests.swift
+++ b/Tests/HelmUITests/RingSpinnerTests.swift
@@ -44,4 +44,46 @@ final class RingSpinnerTests: XCTestCase {
         XCTAssertEqual(first.count, 36)
         XCTAssertTrue(first[10] === second[10], "the frame cache is not returning the same objects")
     }
+    // MARK: - The tint reaches the pixels
+
+    /// Mean colour of the bright pixels — the ring, not the transparent field.
+    private func ringColour(_ token: String) throws -> (r: Double, g: Double, b: Double) {
+        let image = RingIcon.spinnerFrames(style: .ring, size: .medium, tintToken: token)[4]
+        let tiff = try XCTUnwrap(image.tiffRepresentation)
+        let rep = try XCTUnwrap(NSBitmapImageRep(data: tiff))
+        var rs = 0.0, gs = 0.0, bs = 0.0, n = 0.0
+        for y in 0..<rep.pixelsHigh {
+            for x in 0..<rep.pixelsWide {
+                guard let c = rep.colorAt(x: x, y: y), c.alphaComponent > 0.5 else { continue }
+                rs += c.redComponent; gs += c.greenComponent; bs += c.blueComponent; n += 1
+            }
+        }
+        XCTAssertGreaterThan(n, 0, "«\(token)» drew nothing")
+        return (rs / n * 255, gs / n * 255, bs / n * 255)
+    }
+
+    /// The half of the VPN spin that no test reached: a token chosen in Settings
+    /// has to arrive in the drawn frames. `VPNStatusAppearanceTests` proves the
+    /// firing's kind picks the right token, and this proves the token becomes
+    /// that colour — the live check was not available, because the tunnel on the
+    /// development machine never comes up and a connect that changed nothing is
+    /// deliberately not announced.
+    func testTheSpinTintIsTheColourDrawn() throws {
+        let cyan = try ringColour("cyan")
+        let red = try ringColour("red")
+
+        XCTAssertGreaterThan(cyan.b, cyan.r + 25, "cyan is not blue-dominant: \(cyan)")
+        XCTAssertGreaterThan(red.r, red.b + 25, "red is not red-dominant: \(red)")
+        XCTAssertGreaterThan(red.r, red.g + 25)
+    }
+
+    /// Two tokens must not draw the same picture — the cache is keyed by tint,
+    /// and a key that ignored it would serve one colour for both.
+    func testTwoTintsAreTwoPictures() throws {
+        let a = try XCTUnwrap(RingIcon.spinnerFrames(style: .ring, size: .medium,
+                                                     tintToken: "cyan")[4].tiffRepresentation)
+        let b = try XCTUnwrap(RingIcon.spinnerFrames(style: .ring, size: .medium,
+                                                     tintToken: "red")[4].tiffRepresentation)
+        XCTAssertNotEqual(a, b, "the tint is not reaching the cache key")
+    }
 }


### PR DESCRIPTION
Two tests, and no production code. Both exist because the thing they cover
could not be verified by hand on the development machine — and both turned out
to be the better answer anyway, because one look proves one case while a test
proves it at every build.

The rest of this session's work (0.8.0-dev.1 through dev.3, including the
`.lproj` migration) is already on `main`. This is only what came after.

## `test(vpn): the spin's colour reaches the pixels`

That a VPN firing's *kind* picks the right colour token was already pinned by
`VPNStatusAppearanceTests`. What nothing reached was the other half: that the
token becomes that colour in the drawn frames, and that two tokens are not one
cached picture.

The live check is not available here. The rule fires — `connect vpn#73af (auto)`
is in the log — but the L2TP tunnel never comes up, and *a connect that changed
nothing is deliberately not announced*, so no spin follows and there is nothing
to photograph. (Worth knowing separately: that rule fires and the tunnel fails.
220 frames of the menu bar at 10 fps, ring white throughout.)

So the test renders through the same call `StatusItemController` makes and
measures the bright pixels: cyan must be blue-dominant, red red-dominant, by 25
of 255.

**Verified to fail on a real regression.** Forcing `"red"` to map to
`.systemCyan` in `RingIcon.nsColor` turns both tests red:
`red is not red-dominant: (r: 108, g: 208, b: 249)` and
`the tint is not reaching the cache key`.

## `test(reset): the deletion, exercised on a home it may destroy`

`ResetPlanTests` asks the gate questions. This asks the machinery: hand
`HelmTrash` what `ResetPlan` produces, against a real tree under a temporary
home, and see what survives.

- the two Helm directories go
- three neighbours stay — including `Helmet`, the sibling whose name starts the
  same way
- so do the containers a careless plan would have named: `Application Support`,
  `Logs`, `Library`, the home itself
- `freedBytes > 0`, so the move to the Trash actually happened rather than being
  reported

This is the only part of "reset everything" with logic to get wrong; the other
two steps are `removePersistentDomain` and a relaunch, one system call each.

**Verified to fail on a real regression.** Widening the gate to
`~/Library/Application Support` makes both `ResetPlanTests` and this one fail,
the latter with `a reset destroyed …/Sketch/file.txt` — a neighbour's file, by
name.

## Why the button was not pressed

Helm's status item sits on a second display and macOS stopped delivering
synthesized clicks to it partway through the session; five attempts across
`CGEvent` and the Accessibility API would not reopen the panel. The reset was
therefore never run against real state — deliberately, since it would have
trashed the maintainer's own Autopilot rules and forgotten their preferences,
and `UserDefaults` cannot be un-trashed.

## Reviewer notes

- `swift test`: **1623 tests, 0 failures**.
- No production code changes, so nothing here can regress behaviour; the two
  temporary regressions used to prove the guards were reverted and the suite
  re-run green.
- Still unverified against a live machine, unchanged from dev.3: the spin's
  colours in the menu bar with a tunnel that actually connects, and the reset
  button end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
