### PR TITLE
The removal tests waited for nothing, and counted it

### DIFF
--- a/Sources/Modules/KeepAwake/Engine/ClamshellCoordinator.swift
+++ b/Sources/Modules/KeepAwake/Engine/ClamshellCoordinator.swift
@@ -567,6 +567,21 @@ final class ClamshellCoordinator: @unchecked Sendable {
         }
     }
 
+    /// Everything this coordinator has queued has run.
+    ///
+    /// `removeGrant` ends in `shell.async`, so a caller that awaits the command
+    /// and then counts is counting a subject still in motion: the ask happens on
+    /// `shell`, not on the thread that sent the command. On an idle machine the
+    /// queue wins that race and on a loaded one it does not, which is how
+    /// `TheRemovalPromptIsAPromptTooTests` failed once in a full suite on
+    /// 2026-08-25 and never once alone — and, worse, how its «no second dialog»
+    /// assertions could pass over a second dialog that simply had not happened
+    /// yet. `shell` is serial, so a block enqueued after the work runs after it:
+    /// an ordering fact, not a sleep, the same shape as the file's `drainMain`.
+    func drainForTests() async {
+        await withCheckedContinuation { done in shell.async { done.resume() } }
+    }
+
     /// The one place a removal's answer is read, whichever route made it.
     private func finishedRemoving(_ removed: Bool) {
         // **Which rule survived decides who is being talked about.** Both

--- a/Sources/Modules/KeepAwake/Engine/KeepAwakeEngine.swift
+++ b/Sources/Modules/KeepAwake/Engine/KeepAwakeEngine.swift
@@ -681,6 +681,11 @@ public final class KeepAwakeEngine: ModuleEngine, @unchecked Sendable {
     /// payload to say so.
     func settingsChangedForTests() { settingsChanged() }
 
+    /// Everything the lid coordinator queued has run — the removal prompt is
+    /// asked for on its own queue, so a test that counts the asks must wait for
+    /// it. See `ClamshellCoordinator.drainForTests`.
+    func drainClamshellForTests() async { await lid.drainForTests() }
+
     private func cancelTimers() {
         jiggleToken = nil
         batteryToken = nil

--- a/Tests/Modules/KeepAwake/EngineTests/TheRemovalPromptIsAPromptTooTests.swift
+++ b/Tests/Modules/KeepAwake/EngineTests/TheRemovalPromptIsAPromptTooTests.swift
@@ -20,19 +20,40 @@ import HelmRuntime
 /// So this one holds the completion, and `isSudoersInstalled()` goes on
 /// answering yes until the prompt is answered. That is the state the real port
 /// is in for minutes at a time.
-private final class RemovalPromptClamshell: ClamshellPort {
-    var sudoersInstalled = true
-    var pmset = ""
-    private(set) var removeCount = 0
-    private(set) var installCount = 0
+/// **Every field here is written on one thread and read on another.** The ask
+/// runs inside `shell.async` on the coordinator's own queue; the test reads the
+/// counts on the main actor. One lock and the fields behind it, the shape
+/// `ProgressBox` carries for the same reason — the barrier below orders the two,
+/// and the lock is what makes the read of a plain `Int` legal rather than merely
+/// lucky.
+private final class RemovalPromptClamshell: ClamshellPort, @unchecked Sendable {
+    private let lock = NSLock()
+    private var installed = true
+    private var removes = 0
+    private var installs = 0
+    private var report = ""
     private var pendingRemovals: [(Bool) -> Void] = []
 
-    func canDisableSleepWithoutPassword() -> Bool { sudoersInstalled }
-    func isSudoersInstalled() -> Bool { sudoersInstalled }
+    private func locked<T>(_ body: () -> T) -> T {
+        lock.lock(); defer { lock.unlock() }; return body()
+    }
+
+    var sudoersInstalled: Bool {
+        get { locked { installed } }
+        set { locked { installed = newValue } }
+    }
+    var pmset: String {
+        get { locked { report } }
+        set { locked { report = newValue } }
+    }
+    var removeCount: Int { locked { removes } }
+    var installCount: Int { locked { installs } }
+
+    func canDisableSleepWithoutPassword() -> Bool { locked { installed } }
+    func isSudoersInstalled() -> Bool { locked { installed } }
 
     func installSudoers(_ done: @escaping @Sendable (Bool) -> Void) {
-        installCount += 1
-        sudoersInstalled = true
+        locked { installs += 1; installed = true }
         done(true)
     }
 
@@ -45,21 +66,26 @@ private final class RemovalPromptClamshell: ClamshellPort {
 
     /// The prompt goes up and stays up. The file is still there.
     func removeSudoers(_ done: @escaping @Sendable (Bool) -> Void) {
-        removeCount += 1
-        pendingRemovals.append(done)
+        locked { removes += 1; pendingRemovals.append(done) }
     }
 
     /// The person typed their password (or clicked Cancel). Only now does the
     /// file go — and only if they said yes.
     func answerRemovalPrompts(granted: Bool) {
-        let waiting = pendingRemovals
-        pendingRemovals = []
-        if granted { sudoersInstalled = false }
+        // The completions are called outside the lock: each one re-enters this
+        // fake through `finishedRemoving`, and a lock held across that is a
+        // deadlock waiting for the first port that answers on the same thread.
+        let waiting: [(Bool) -> Void] = locked {
+            let held = pendingRemovals
+            pendingRemovals = []
+            if granted { installed = false }
+            return held
+        }
         for done in waiting { done(granted) }
     }
 
     func setDisableSleep(_ on: Bool) -> Bool { true }
-    func pmsetReport() -> String { pmset }
+    func pmsetReport() -> String { locked { report } }
 }
 
 /// Switching «stay awake with the lid closed» off takes the passwordless-sudo
@@ -113,10 +139,26 @@ final class TheRemovalPromptIsAPromptTooTests: XCTestCase {
         engine.activate()
     }
 
-    /// What the settings page sends when anything on it moves.
+    /// What the settings page sends when anything on it moves — **and the app
+    /// having finished acting on it**, which is not the same instant.
+    ///
+    /// `send` awaits the command handler, and the handler is done once it has
+    /// put the removal on the coordinator's own queue. The ask itself — the
+    /// thing every assertion in this file counts — happens on that queue
+    /// afterwards. Counting straight after the `await` counted a subject still
+    /// in motion: it failed once in a full suite on 2026-08-25 and passed 5/5
+    /// alone, 5/5 as a class and 3/3 as a bundle, because an idle queue always
+    /// won the race. Slowing the queue by 50 ms failed **all seven** tests here,
+    /// which is the measure of how little the green had been worth.
+    ///
+    /// The barrier belongs here rather than at each assertion so the negative
+    /// cases get it too: «no second dialog» over a second dialog that had not
+    /// happened yet is an absence assertion passing on a subject that never
+    /// occurred.
     private func settingsChanged() async {
         _ = try? await engine.transport.send(
             EngineCommand(name: KeepAwakeCommand.settingsChanged.rawValue))
+        await engine.drainClamshellForTests()
     }
 
     /// The gesture: the switch moves, and the page says so the only way it can.
@@ -238,6 +280,7 @@ final class TheRemovalPromptIsAPromptTooTests: XCTestCase {
         XCTAssertFalse(clamshell.sudoersInstalled, "precondition: the rule is gone")
 
         engine.startSession(minutes: 0)
+        await engine.drainClamshellForTests()
         await drainMain()
 
         XCTAssertEqual(clamshell.installCount, 1,


### PR DESCRIPTION
`TheRemovalPromptIsAPromptTooTests` failed once in a full suite on 2026-08-25 and
then passed 5/5 alone, 5/5 as a class and 3/3 as its own bundle. The failure was
on a *precondition* — `("0") is not equal to ("1") — precondition: one prompt is
up` — which is the tell: what broke was not the thing under test but something
the test took for granted.

## What was wrong

The test counts a subject that is still moving.

```swift
await switchTheOption(false)                       // waits for the command handler
XCTAssertEqual(clamshell.removeCount, 1, "precondition: one prompt is up")
```

`send` does wait — `try await currentHandler(c)`. But the handler reaches
`releaseIfUnneeded` → `removeGrant`, and `removeGrant` ends in:

```swift
shell.async { [self] in
    if clamshell.removeSudoersWithoutPassword() { finishedRemoving(true) }
    else { clamshell.removeSudoers { … } }          // removeCount += 1 happens here
}
```

`shell` is a serial background queue. `async` returns immediately, so the awaited
command finishes having only *enqueued* the ask. Whether the assertion one line
later sees 1 or 0 is a race with the scheduler — which an idle machine wins
almost every time, and a machine running 24 test bundles does not.

**The hop stays.** `osascript … with administrator privileges` blocks for as long
as the person takes to find their password; that does not belong on the thread
that draws. The defect is in the test, not the app.

**All seven tests had it**, not just the one that lost. `testTurningTheOptionOff…`
does the identical thing at line 133 and passed in the same run.

## The proof

Slowing the queue by 50 ms — `Thread.sleep` inside the block, dispatch semantics
untouched — makes the difference visible in both directions:

| | busy queue |
|---|---|
| before this change | **7 of 7 failed** |
| after | **7 of 7 passed**, durations 0.001 s → 0.057 s |

The durations are the point: the tests now wait rather than win.

A first attempt at that measurement used `shell.asyncAfter(+0.05)` and appeared
to show the fix not working. It showed something else — `asyncAfter` does not
hold a serial queue against a later `async`, so the barrier overtook the delayed
block. That models a delayed dispatch, not a busy queue, and the real call is
`shell.async`. A mutation has to move the thing under suspicion.

## What changed

- `ClamshellCoordinator.drainForTests` — a block enqueued after the work on the
  same serial queue. An ordering fact, not a sleep; the same shape as this
  file's own `drainMain`.
- `KeepAwakeEngine.drainClamshellForTests` forwards it, the way it already
  forwards `settingsChangedForTests`.
- The barrier goes inside the test's `settingsChanged()` rather than at each
  assertion, so the negative cases get it too. "No second dialog" over a dialog
  that had not happened yet is an absence assertion passing because its subject
  never occurred — those cases could have gone on proving nothing.
- `RemovalPromptClamshell` goes under a lock. Its counters were written on
  `shell` and read on the main actor: a data race independent of the timing.
  Completions are called outside the lock — each re-enters the fake through
  `finishedRemoving`.

## Verification

Full suite: **24/24 bundles, 0 failing bundles across the whole log, 0 failed
cases.** The class alone, three times: 7/7 each.

A sweep for the same defect elsewhere — every test that counts a fake's counter
straight after awaiting a command — found three candidates without a barrier and
none of them at risk: `forgetKnownHost` does not hop and the Hosts fakes already
lock their counters, `tap.start()` is synchronous, `prevent()` is synchronous.
